### PR TITLE
Sort written snapshots

### DIFF
--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -151,9 +151,10 @@ class SnapshotModule(object):
         pretty = Formatter(self.imports)
 
         with codecs.open(self.filepath, 'w', encoding="utf-8") as snapshot_file:
-            snapshots_declarations = []
-            for key, value in self.snapshots.items():
-                snapshots_declarations.append('''snapshots['{}'] = {}'''.format(key, pretty(value)))
+            snapshots_declarations = [
+                """snapshots['{}'] = {}""".format(key, pretty(self.snapshots[key]))
+                for key in sorted(self.snapshots.keys())
+            ]
 
             imports = '\n'.join([
                 'from {} import {}'.format(module, ', '.join(sorted(module_imports)))


### PR DESCRIPTION
Enforce sorting of snapshots when writing to the snapshot file.

This helps creating smaller diffs, as no more "random" reordering
occurs, making code reviews easier.